### PR TITLE
Update csv-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "JSONStream": "^1.0.4",
     "concat-stream": "^1.4.6",
-    "csv-stream": "~0.1.3",
+    "csv-stream": ">0.1.3",
     "duplexer": "~0.1.1",
     "j": "^0.4.3",
     "minimist": "^1.1.1",


### PR DESCRIPTION
The 0.1.3 version of `csv-stream` has trouble on modern node versions around encoding.  Update our dependency to the latest version which deals with the problem.

Further details on the CSV changes:
https://github.com/lbdremy/node-csv-stream/issues/13